### PR TITLE
docs: ADR for Feature boundary + non-blocking UI; add Feature Manager…

### DIFF
--- a/docs/adr/0001-feature-boundary-bedrock.md
+++ b/docs/adr/0001-feature-boundary-bedrock.md
@@ -1,0 +1,24 @@
+# ADR 0001: Feature boundary & Execution Copy residency
+
+**Status:** Accepted  
+**Date:** 2025-10-03
+
+## Context
+Phoenix must remain highly responsive. Editors, Analysis Windows, and Tools are UI controllers; Bedrock performs all computation. We need a clear boundary that avoids blocking the GUI thread and keeps model state centralized.
+
+## Decision
+- **Execution Copies (ECs)** are created, owned, and managed **only by Bedrock**.
+- Phoenix invokes Bedrock via a **Feature Manager** facade that is **asynchronous, cancellable, and coalescing**; the GUI thread never blocks.
+- **Analysis Windows** specify a feature + params and render **typed results** (e.g., spot data arrays). View-local transforms (log scale, contouring) are UI-only.
+- **Tools** operate on a Bedrock-held EC; **commit()** promotes EC → canonical SOM and emits a “SOMChanged” event; **discard()** drops it.
+- The boundary is transport-agnostic: in-process now; IPC later without changing the UI API.
+
+## Consequences
+- UI code remains simple and responsive.
+- All compute and copy semantics are centralized in Bedrock.
+- Licensing/telemetry can be enforced cleanly at the Feature boundary.
+
+## References
+- `docs/feature-manager.md`
+- Bedrock `docs/engine-api.md`
+- Rosetta `docs/som-overview.md`

--- a/docs/feature-manager.md
+++ b/docs/feature-manager.md
@@ -1,0 +1,26 @@
+# Feature Manager (Phoenix facade)
+
+A non-blocking, cancellable, telemetry-aware boundary between Phoenix and Bedrock.
+
+## Goals
+- Zero GUI-thread blocking (async only).
+- Coalesce rapid changes; cancel stale jobs.
+- Enforce licensing at the call site.
+- Emit progress and results via signals.
+
+## API (UI-facing sketch)
+- `request(feature_id, params, exec_id, priority) -> ticket`
+- Signals: `started(job_id)`, `progress(job_id, %)`, `finished(job_id, payload, meta)`, `failed(job_id, code, reason)`
+- `cancel(ticket)`, `cancelByWindow(ctx)`, `setThrottle(ctx, ms)`
+
+## Threading
+- GUI thread: dispatches requests; never blocks.
+- Dispatcher thread: licensing + telemetry; forwards to Bedrock.
+- Bedrock threadpool: performs compute; emits queued signals back.
+
+## Licensing & Telemetry
+- License gate by `feature_id` (stub OK for MVP).
+- Telemetry per call: feature_id, params-hash, duration, success (opt‑in; no PII). See `docs/telemetry-policy.md`.
+
+## Payloads
+Results are typed blobs (e.g., FITS/HDF5/binary) plus small JSON/metadata suitable for charts/tables. Phoenix applies only view-local transforms.

--- a/docs/telemetry-policy.md
+++ b/docs/telemetry-policy.md
@@ -1,0 +1,16 @@
+# Telemetry Policy (Phoenix)
+
+Phoenix records **Feature** usage at the UI↔Bedrock boundary to improve UX and performance.
+
+## Principles
+- **Opt‑in** (default off in developer builds).
+- **No PII** and no project/lens contents.
+- Local buffering and periodic upload.
+- Clear in-app controls to view/opt-out.
+
+## Events
+- `feature.requested` (feature_id, params_hash)
+- `feature.finished` (duration_ms, success, payload_size)
+- `feature.failed` (error_code, error_reason)
+
+Transport is pluggable: start with local NDJSON logs; add HTTPS batch upload later.


### PR DESCRIPTION
… & telemetry docs

## Summary
- Add ADR 0001 documenting that Execution Copies (ECs) live only in Bedrock and Phoenix is an async, request/response UI.
- Add Feature Manager facade doc (non-blocking, cancellable, coalescing; licensing & telemetry checkpoints).
- Add telemetry policy stub (opt-in, no PII, local buffering).

## Why
Locks our plumbing decisions so Stage 2 work doesn’t drift. Keeps the GUI thread free and centralizes compute in Bedrock.

## Files
- README.md: short “How Phoenix talks to Bedrock”
- docs/adr/0001-feature-boundary-bedrock.md
- docs/feature-manager.md
- docs/telemetry-policy.md

## Checks
- ✅ Build check should pass (no code changes)
- ℹ️ CodeQL present (not required)

<!--
Thank you for your contribution to Phoenix! Please review the following checklist before submitting your pull request.
-->

## Summary

<!-- Explain what this change does and why it's needed. -->

## Related Issues / RFCs

<!-- List any related issues or RFCs. Include "Closes #" if this PR closes an issue. -->

## Tests & Benchmarks

- [ ] Unit tests added/updated
- [ ] Baselines/benchmarks unchanged or improved

## Notes

<!-- Add any additional notes or context. -->

## AI Assist (provenance)

- [ ] No AI used
- [ ] Yes (tool: Copilot/Claude/Other): <scope description>

## Safety & Licensing

- [ ] No secrets or proprietary data included
- [ ] License headers and attributions checked
