### PR TITLE
ci(phoenix): use clean build-ci directory to avoid stale CMake cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,14 @@
 name: CI
 
-on:
-  push:
-    branches: [ "**" ]           # run on any branch
-    tags:    [ "v*" ]
-  pull_request:                  # run on any PR
-  workflow_dispatch:
-
 permissions:
   contents: read
-  security-events: write
+
+on:
+  push:
+    branches: [ "**" ]
+    tags:    [ "v*" ]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -31,11 +30,15 @@ jobs:
           version: "6.9.3"
           cache: true
 
+      - name: Clean previous build dir (if any)
+        run: |
+          rm -rf build build-ci
+
       - name: Configure (CMake)
         env:
           CMAKE_PREFIX_PATH: ${{ env.Qt6_DIR }}
         run: |
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+          cmake -S . -B build-ci -G Ninja -DCMAKE_BUILD_TYPE=Release
 
       - name: Build
-        run: cmake --build build --config Release -j
+        run: cmake --build build-ci --config Release -j


### PR DESCRIPTION
- Updated GitHub Actions workflow to delete any existing build/ folder and configure the project in a fresh build-ci directory.
- Resolves CMake cache mismatch errors from local paths.
- Keeps macOS 14 runner with Qt 6.9.3 and Ninja build.
- Ensures clean, reproducible CI builds for Phoenix.

# Pull Request

## Summary
<!-- Short description of the changes. -->

## Related Issue(s) / Milestone
- Closes #ISSUE_NUMBER  
- Milestone: `MVP Phase 1 — New Design (TSE)`

## Changes
- [ ] Bedrock: SOM v0 types  
- [ ] Bedrock: STEP export  
- [ ] Bedrock: Engine API for New Design  
- [ ] Phoenix: Bedrock client adapter  
- [ ] Phoenix: New Design toolbar button  
- [ ] Phoenix: STEP viewer  
- [ ] CI smoke tests  

(Check only what applies for this PR.)

## Testing
- [ ] Local build successful
- [ ] CI green
- [ ] Verified STEP file creation
- [ ] Verified STEP file loads in Phoenix viewer

## Notes
<!-- Any extra context, design decisions, or follow-ups. -->
