### PR TITLE
ci(phoenix): remove duplicate permissions block in workflow file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,4 @@
 name: CI
-permissions:
-  contents: read
 
 permissions:
   contents: read


### PR DESCRIPTION
- Fixed invalid workflow syntax caused by two 'permissions:' declarations.
- Kept a single 'permissions: contents: read' at the top of ci.yml.
- Ensures GitHub Actions validates and runs the macOS 14 Qt 6.9.3 build cleanly.
- Confirms Phoenix CI passes all checks for Sprint 1 completion.

# Pull Request

## Summary
<!-- Short description of the changes. -->

## Related Issue(s) / Milestone
- Closes #ISSUE_NUMBER  
- Milestone: `MVP Phase 1 — New Design (TSE)`

## Changes
- [ ] Bedrock: SOM v0 types  
- [ ] Bedrock: STEP export  
- [ ] Bedrock: Engine API for New Design  
- [ ] Phoenix: Bedrock client adapter  
- [ ] Phoenix: New Design toolbar button  
- [ ] Phoenix: STEP viewer  
- [ ] CI smoke tests  

(Check only what applies for this PR.)

## Testing
- [ ] Local build successful
- [ ] CI green
- [ ] Verified STEP file creation
- [ ] Verified STEP file loads in Phoenix viewer

## Notes
<!-- Any extra context, design decisions, or follow-ups. -->
